### PR TITLE
Fix: Entity index params resolution on getter + .dot + array notation in multiple indexes at once (v3.1.3)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # DynamoDB Provider Changelog
 
+# v3.1.3
+
+- **Fix**: Entity index params resolution would be `never` if you used multiple indexes that had array .notations and getters on different keys - entity would not be recognized on any helpers etc
+
 # v3.1.2
 
 - **Fix**: partition `keySwap` param merger is now resilient to receiving a Proxy inspector object - vital for our upcoming playground to infer the params

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://github.com/fabiosenracorrea/dynamodb-provider",
   "author": "fabiosenracorrea",
   "name": "dynamodb-provider",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A dynamodb Provider that simplifies the native api. It packs with a Single Table adaptor/pseudo ORM for single table design",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/singleTable/model/definitions/entity/indexParams.ts
+++ b/src/singleTable/model/definitions/entity/indexParams.ts
@@ -40,7 +40,7 @@ type EntityIndexConfig<
     [key in TableIndex]?: Partial<SingleTableKeyReference>;
   };
 
-  getUpdatedIndexMapping: (params: IndexParams<Entity, IndexConfig>) => {
+  getUpdatedIndexMapping: (params: Partial<IndexParams<Entity, IndexConfig>>) => {
     [key in TableIndex]?: Partial<SingleTableKeyReference>;
   };
 };

--- a/src/singleTable/model/definitions/indexes.ts
+++ b/src/singleTable/model/definitions/indexes.ts
@@ -2,6 +2,7 @@
 
 import { SingleTableConfig } from 'singleTable/adaptor';
 
+import { IsUnknown, PrettifyObject, UnionToIntersection } from 'types';
 import { EntityKeyParams, EntityKeyResolvers } from './key';
 import { RangeQueryInputProps } from './range';
 
@@ -22,7 +23,24 @@ export type IndexMapping<
   Entity = undefined,
 > = Record<string, SingleIndex<TableConfig, Entity>>;
 
+type __SingleIndexParams<
+  Entity,
+  Index extends SingleIndex<any, any>,
+  __PARAMS__ = EntityKeyParams<Entity, Index>,
+  // necessary as unknown | { something } == unknown
+> = IsUnknown<__PARAMS__> extends true ? never : __PARAMS__;
+
+type __IndexParams<
+  Entity,
+  IndexConfig extends IndexMapping<any, any>,
+  //
+> = UnionToIntersection<
+  {
+    [Index in keyof IndexConfig]: __SingleIndexParams<Entity, IndexConfig[Index]>;
+  }[keyof IndexConfig]
+>;
+
 export type IndexParams<
   Entity,
   IndexConfig extends IndexMapping<any, any>,
-> = EntityKeyParams<Entity, IndexConfig[keyof IndexConfig]>;
+> = PrettifyObject<__IndexParams<Entity, IndexConfig>>;


### PR DESCRIPTION
# v3.1.3

- **Fix**: Entity index params resolution would be `never` if you used multiple indexes that had array .notations and getters on different keys - entity would not be recognized on any helpers etc
